### PR TITLE
Update setup.py to include semantic_version package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     ],
     install_requires=[
         'requirements-parser>=0.1.0',
+        'semantic_version>=2.5.0',
     ],
     include_package_data=True,
     description='Requirements package monitor for Django projects.',


### PR DESCRIPTION
Previously this package was required as a manual/separate requirement of a specific, commit-pinned, bugfix version.

That bug has now been fixed in `semantic_version==2.5.0`, so this commit adds the official 2.5.0 release as a dependency of django-package-monitor, as separately installing the pinned version is no longer the best approach.